### PR TITLE
Fix django.conf.urls.defaults remove in Django 1.6

### DIFF
--- a/django_resubmit/urls.py
+++ b/django_resubmit/urls.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 from __future__ import absolute_import
 
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls.defaults import patterns, url
+except:
+    from django.conf.urls import patterns, url
 from .views import Preview, Resubmit
 
 

--- a/django_resubmit/urls.py
+++ b/django_resubmit/urls.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import
 
 try:
-    from django.conf.urls.defaults import patterns, url
-except:
     from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from .views import Preview, Resubmit
 
 


### PR DESCRIPTION
More info:
https://docs.djangoproject.com/en/1.6/internals/deprecation/#id1
http://stackoverflow.com/a/19962822